### PR TITLE
fix: changing workflow to use admin PAT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,5 @@
 name: Semantic Release
 
-permissions:
-  contents: write
-  id-token: write
-
 on:
   push:
     branches:
@@ -17,7 +13,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REPO_ADMIN_TOKEN }}
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
@@ -42,4 +38,4 @@ jobs:
       - name: Python Semantic Release
         uses: relekang/python-semantic-release@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
# What

- per [this](https://github.com/python-semantic-release/python-semantic-release/issues/311) issue we are going to use a PAT that is scoped to this repo


# Why

- python semantic release doesn't seem to work with protected repos unless using a PAT. The `GITHUB_OTKEN` doesn't cut it
